### PR TITLE
CI/CD の Node.js を LTS に変更

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,28 +10,29 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [15]
+        node: [12, 14, 16]
+    name: Node ${{ matrix.node }}
     steps:
-    - uses: actions/checkout@main
-    - name: Use Node.js ${{ matrix.node-version }}.x
-      uses: actions/setup-node@main
-      with:
-        node-version: ${{ matrix.node-version }}
-        check-latest: true
-    - name: Cache ~/.pnpm-store
-      uses: actions/cache@main
-      env:
-        cache-name: cache-pnpm-store
-      with:
-        path: ~/.pnpm-store
-        key: ${{ runner.os }}-${{ matrix.node-version }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-${{ matrix.node-version }}-build-
-          ${{ runner.os }}-
-    - name: Install pnpm
-      run: npm i -g pnpm
-    - name: Lint
-      run: |
-        pnpm install
-        pnpm run lint
+      - uses: actions/checkout@main
+      - name: Use Node.js ${{ matrix.node }}.x
+        uses: actions/setup-node@main
+        with:
+          node: ${{ matrix.node }}
+          check-latest: true
+      - name: Cache ~/.pnpm-store
+        uses: actions/cache@main
+        env:
+          cache-name: cache-pnpm-store
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ matrix.node }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ matrix.node }}-build-
+            ${{ runner.os }}-
+      - name: Install pnpm
+        run: npm i -g pnpm
+      - name: Lint
+        run: |
+          pnpm install
+          pnpm run lint


### PR DESCRIPTION
この PR は，CI/CD で使用する Node.js を Active LTS と Maintenance LTS に変更します．
現在の LTS は 12, 14, 16 です．

https://nodejs.org/ja/about/releases/