### PR TITLE
feat: Update Lint workflow badge URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zenn Contents
 
-[![Lint](https://github.com/kou64yama/zenn-contents/workflows/Lint/badge.svg?branch=main&event=push)](https://github.com/kou64yama/zenn-contents/actions?query=workflow:Lint+branch:main+event:push)
+[![Lint](https://github.com/kou64yama/zenn-contents/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/kou64yama/zenn-contents/actions/workflows/lint.yml)
 
 ## Requirements
 


### PR DESCRIPTION
Lint workflow badge URL in README.md has been updated to the new format.